### PR TITLE
Adding PrototypeBootloader, removing Prototyped from repositories

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -7,10 +7,6 @@ server:
     command: "php app.php"
     relay: pipes
 
-# serve static files
-static:
-    dir: "public"
-
 http:
     address: 0.0.0.0:8080
     middleware: [ "gzip", "static" ]

--- a/app/src/App.php
+++ b/app/src/App.php
@@ -98,7 +98,10 @@ class App extends Kernel
 
         // Framework commands
         Framework\CommandBootloader::class,
+
+        // Scaffolding
         Scaffolder\ScaffolderBootloader::class,
+        CycleBridge\ScaffolderBootloader::class,
 
         // Debug and debug extensions
         Framework\DebugBootloader::class,
@@ -118,7 +121,6 @@ class App extends Kernel
 
         // fast code prototyping
         Prototype\PrototypeBootloader::class,
-        Scaffolder\ScaffolderBootloader::class,
-        CycleBridge\ScaffolderBootloader::class,
+        CycleBridge\PrototypeBootloader::class,
     ];
 }

--- a/app/src/Repository/PostRepository.php
+++ b/app/src/Repository/PostRepository.php
@@ -7,9 +7,7 @@ namespace App\Repository;
 use App\Database\Post;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\Repository;
-use Spiral\Prototype\Annotation\Prototyped;
 
-#[Prototyped(property: 'posts')]
 class PostRepository extends Repository
 {
     public function findAllWithAuthor(): Select

--- a/app/src/Repository/UserRepository.php
+++ b/app/src/Repository/UserRepository.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use Cycle\ORM\Select\Repository;
-use Spiral\Prototype\Annotation\Prototyped;
 
-#[Prototyped(property: 'users')]
 class UserRepository extends Repository
 {
 }


### PR DESCRIPTION
This functionality has been added to Cycle Bridge:
https://github.com/spiral/cycle-bridge/pull/46